### PR TITLE
To Show Error when Bad Credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 Plugin/
 node_modules/
+.history/*
+.vscode/*

--- a/counting_prawns.10s.js
+++ b/counting_prawns.10s.js
@@ -15,8 +15,8 @@ const bitbar = require('bitbar');
 
 // Configurable params
 const githubConfig = {
-  accessToken: 'YOUR_ACCESS_TOKEN',
-  username: 'YOUR_USERNAME',
+  accessToken: 'ACCESS_TOKEN',
+  username: 'USERNAME',
   owner: 'Marfeel',
   repos: ['MarfeelXP', 'AliceTenants', 'Gutenberg', 'ProTenants'],
   color: 'green',
@@ -50,7 +50,7 @@ const getPRs = (options) => (
       });
       res.on('end', () => {
         const response = JSON.parse(body);
-        if(response.message) reject(response.message);
+        if (response.message) reject(response.message);
         else resolve(response);
       });
     });
@@ -88,18 +88,18 @@ const getPrDividedByReposAndAssignedToYou = () => (
     prDividedByRepos.map(prs =>
       prs.filter(pr => filterPrsByLoginNames(pr))
     )
-  ).catch((message) => message)
+  )
 );
 
-const getTotalPrAssignedToYou = (prDividedByReposAssignedToYou) => {
-  if(prDividedByReposAssignedToYou instanceof Array) {
-    return prDividedByReposAssignedToYou.reduce((acc, prDividedByRepos) => (
-      acc + prDividedByRepos.length
-    ), 0)
-  } else return prDividedByReposAssignedToYou;
-};
+const getTotalPrAssignedToYou = (prDividedByReposAssignedToYou) => (
+  prDividedByReposAssignedToYou.reduce((acc, prDividedByRepos) => (
+    acc + prDividedByRepos.length
+  ), 0)
+);
 
-const getEmoji = num => (num > 0 ? ':eyeglasses:' : num === 0? ':palm_tree:' : ':x:');
+const getEmoji = num => (num > 0 ? ':eyeglasses:' : ':palm_tree:');
+
+const getErrorEmoji = () => ':x:';
 
 const getColor = darkMode => (darkMode ? 'white' : 'black');
 
@@ -120,11 +120,22 @@ const getStyledTitle = numberOfPr => `${getEmoji(numberOfPr)} ${numberOfPr}`;
 const getRepoName = prs => prs[0].base.repo.name;
 
 /* TODO: This method should have been called as soon as i get the data, not here. Needs refacor */
-const getCleanPrAssignedToYouDividedByRepos = prAssignedToYouDividedByRepos => {
-  if(prAssignedToYouDividedByRepos instanceof Array) {
-    prAssignedToYouDividedByRepos.filter(prAssignedToYou => prAssignedToYou.length)
-  }
-  return [];
+const getCleanPrAssignedToYouDividedByRepos = prAssignedToYouDividedByRepos => (
+  prAssignedToYouDividedByRepos.filter(prAssignedToYou => prAssignedToYou.length)
+);
+
+const bitbarBuildHeading = (text, bitbarConfigVars) => {
+  const {
+    darkMode,
+    sep,
+  } = bitbarConfigVars;
+
+  const heading = {
+    text,
+    color: getColor(darkMode),
+    dropdown: false,
+  };
+  return Array.of(heading, sep);
 };
 
 const bitbarObjectBuilder = (prAssignedToYouDividedByRepos, bitbarConfigVars) => {
@@ -135,12 +146,6 @@ const bitbarObjectBuilder = (prAssignedToYouDividedByRepos, bitbarConfigVars) =>
     sep,
   } = bitbarConfigVars;
 
-  const heading = {
-    text: getStyledTitle(totalPrAssignedToYou),
-    color: getColor(darkMode),
-    dropdown: false,
-  };
-
   const formattedPr = cleanPrAssignedToYouDividedByRepos.map(prs => (
     {
       text: `${getRepoName(prs)} ${getStyledTitle(prs.length)}`,
@@ -149,14 +154,14 @@ const bitbarObjectBuilder = (prAssignedToYouDividedByRepos, bitbarConfigVars) =>
     }
   ));
 
-  return Array.of(heading, sep).concat(formattedPr);
+  return bitbarBuildHeading(getStyledTitle(totalPrAssignedToYou), bitbarConfigVars).concat(formattedPr);
 };
 
 const paintBitBar = () => {
   getPrDividedByReposAndAssignedToYou().then((prAssignedToYou) => {
     bitbar(bitbarObjectBuilder(prAssignedToYou, bitbar));
   }).catch((errorMessage) => {
-    bitbar(bitbarObjectBuilder(errorMessage, bitbar));
+    bitbar(bitbarBuildHeading(`${getErrorEmoji()} ${errorMessage}`, bitbar));
   });
 };
 

--- a/counting_prawns.10s.js
+++ b/counting_prawns.10s.js
@@ -15,8 +15,8 @@ const bitbar = require('bitbar');
 
 // Configurable params
 const githubConfig = {
-  accessToken: 'c4b066076a28fa923be6414db48a559daae42a4b',
-  username: 'dominguezcelada',
+  accessToken: 'YOUR_ACCESS_TOKEN',
+  username: 'YOUR_USERNAME',
   owner: 'Marfeel',
   repos: ['MarfeelXP', 'AliceTenants', 'Gutenberg', 'ProTenants'],
   color: 'green',

--- a/counting_prawns.10s.js
+++ b/counting_prawns.10s.js
@@ -15,8 +15,8 @@ const bitbar = require('bitbar');
 
 // Configurable params
 const githubConfig = {
-  accessToken: 'ACCESS_TOKEN',
-  username: 'USERNAME',
+  accessToken: '',
+  username: 'YOUR_USERNAME',
   owner: 'Marfeel',
   repos: ['MarfeelXP', 'AliceTenants', 'Gutenberg', 'ProTenants'],
   color: 'green',

--- a/counting_prawns.10s.js
+++ b/counting_prawns.10s.js
@@ -15,8 +15,8 @@ const bitbar = require('bitbar');
 
 // Configurable params
 const githubConfig = {
-  accessToken: '',
-  username: 'YOUR_USERNAME',
+  accessToken: 'c4b066076a28fa923be6414db48a559daae42a4b',
+  username: 'dominguezcelada',
   owner: 'Marfeel',
   repos: ['MarfeelXP', 'AliceTenants', 'Gutenberg', 'ProTenants'],
   color: 'green',
@@ -49,7 +49,9 @@ const getPRs = (options) => (
         body += chunk;
       });
       res.on('end', () => {
-        resolve(JSON.parse(body));
+        const response = JSON.parse(body);
+        if(response.message) reject(response.message);
+        else resolve(response);
       });
     });
 
@@ -86,16 +88,18 @@ const getPrDividedByReposAndAssignedToYou = () => (
     prDividedByRepos.map(prs =>
       prs.filter(pr => filterPrsByLoginNames(pr))
     )
-  )
+  ).catch((message) => message)
 );
 
-const getTotalPrAssignedToYou = (prDividedByReposAssignedToYou) => (
-  prDividedByReposAssignedToYou.reduce((acc, prDividedByRepos) => (
-    acc + prDividedByRepos.length
-  ), 0)
-);
+const getTotalPrAssignedToYou = (prDividedByReposAssignedToYou) => {
+  if(prDividedByReposAssignedToYou instanceof Array) {
+    return prDividedByReposAssignedToYou.reduce((acc, prDividedByRepos) => (
+      acc + prDividedByRepos.length
+    ), 0)
+  } else return prDividedByReposAssignedToYou;
+};
 
-const getEmoji = num => (num > 0 ? ':eyeglasses:' : ':palm_tree:');
+const getEmoji = num => (num > 0 ? ':eyeglasses:' : num === 0? ':palm_tree:' : ':x:');
 
 const getColor = darkMode => (darkMode ? 'white' : 'black');
 
@@ -116,9 +120,12 @@ const getStyledTitle = numberOfPr => `${getEmoji(numberOfPr)} ${numberOfPr}`;
 const getRepoName = prs => prs[0].base.repo.name;
 
 /* TODO: This method should have been called as soon as i get the data, not here. Needs refacor */
-const getCleanPrAssignedToYouDividedByRepos = prAssignedToYouDividedByRepos => (
-  prAssignedToYouDividedByRepos.filter(prAssignedToYou => prAssignedToYou.length)
-);
+const getCleanPrAssignedToYouDividedByRepos = prAssignedToYouDividedByRepos => {
+  if(prAssignedToYouDividedByRepos instanceof Array) {
+    prAssignedToYouDividedByRepos.filter(prAssignedToYou => prAssignedToYou.length)
+  }
+  return [];
+};
 
 const bitbarObjectBuilder = (prAssignedToYouDividedByRepos, bitbarConfigVars) => {
   const totalPrAssignedToYou = getTotalPrAssignedToYou(prAssignedToYouDividedByRepos);
@@ -148,6 +155,8 @@ const bitbarObjectBuilder = (prAssignedToYouDividedByRepos, bitbarConfigVars) =>
 const paintBitBar = () => {
   getPrDividedByReposAndAssignedToYou().then((prAssignedToYou) => {
     bitbar(bitbarObjectBuilder(prAssignedToYou, bitbar));
+  }).catch((errorMessage) => {
+    bitbar(bitbarObjectBuilder(errorMessage, bitbar));
   });
 };
 


### PR DESCRIPTION
## Description
To show an error message when Github API credentials are not intruded or are intruded wrong.

## Expected behavior
* To show up the counted PR as usual if the connection to Github's API has succeed.
* To show an error message if the connection was not possible (and the message Github's API is returning to have more info).
![image](https://cloud.githubusercontent.com/assets/2574275/21298031/a3b4821a-c58a-11e6-98ee-ee0e527f081a.png)


## Implementation
* Controlling the HTTP Request response to check if it has an error message.
* Resolve or reject the promise of the HTTP request depending on the error message.
* To catch properly the rejected promise and manage the error message.
* To control when the request fails and show up the error message.

## Fixes
* #17 
* #22 -> Not able to test, but in theory is the same pattern.